### PR TITLE
Update astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 
 import tailwind from "@astrojs/tailwind";
 
+// Import the Vercel adapter
 import vercel from '@astrojs/vercel/serverless';
 
 // https://astro.build/config


### PR DESCRIPTION
To use server-side rendering, an adapter needs to be installed so Astro knows how to generate the proper output for your targeted deployment platform.